### PR TITLE
undo the query string escaping characters added by WP

### DIFF
--- a/plugin/class-facet-searchword.php
+++ b/plugin/class-facet-searchword.php
@@ -41,7 +41,7 @@ class Facet_Searchword implements Facet
 
 	function parse_query( $query_terms , $wp_query )
 	{
-		$term = wp_kses( trim( urldecode( $query_terms ) ), array() );
+		$term = wp_kses( trim( urldecode( stripslashes( $query_terms ) ) ), array() );
 		$this->selected_terms[ $term ] = (object) array(
 			'facet' => $this->name,
 			'slug' => urlencode( $term ),


### PR DESCRIPTION
see https://github.com/GigaOM/legacy-pro/issues/1131
