### PR TITLE
give the filter applied by Facet_Searchword a new name

### DIFF
--- a/plugin/class-facet-searchword.php
+++ b/plugin/class-facet-searchword.php
@@ -207,7 +207,7 @@ class Facet_Searchword implements Facet
 		}
 
 		// scriblio-authority is hooked to this filter
-		return apply_filters( 'scriblio_facet_taxonomy_terms', $terms, '', FALSE );
+		return apply_filters( 'scriblio_searchword_to_taxonomy_terms', $terms );
 	}//END get_taxonomy_terms
 
 	/**


### PR DESCRIPTION
instead of using the same one used by `Facet_Taxonomy`

as part of https://github.com/GigaOM/legacy-pro/issues/3995
